### PR TITLE
Optimise release build size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["strip"]
+
 [workspace]
 
 members = [
@@ -5,3 +7,7 @@ members = [
     "xen",
     "xen-sys"
 ]
+
+[profile.release]
+strip = true
+lto = true

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-# Helper script for `cargo run` command: writes config file and starts VM
+# Helper script for `cargo run` command
+
+# print section sizes
+size $1
+
+# print total size
+dua $1
 
 # create temporary file for config
 temp_file=$(mktemp)
@@ -8,9 +14,11 @@ temp_file=$(mktemp)
 # delete temporary file after signal (0: exit shell, 2: interrupt, 3: quit, 15: terminate)
 trap "rm -f $temp_file" 0 2 3 15
 
+# create config fuke
 echo "kernel = \"$1\"" >> $temp_file
 echo "memory = 4" >> $temp_file
 echo "name = \"stardust\"" >> $temp_file
 echo "on_crash = 'destroy'" >> $temp_file
 
+# start VM
 sudo xl create -c $temp_file

--- a/stardust/src/main.rs
+++ b/stardust/src/main.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(const_raw_ptr_to_usize_cast)]
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]


### PR DESCRIPTION
Optimisations Enabled | Binary Size
-|-
Initial | 102.40 KB
Stripping | 81.92 KB
Stripping + LTO | 69.63 KB
Stripping + LTO + `codegen-units 1` | 73.73 KB

Setting `codegen-units =  1` strangely *increased* code size so is not enabled in this PR. The major optimisation left out is setting `opt-level = "z"` which prioritised size optimisations over speed but performance is the primary goal and a smaller size is just a useful property to have.