### PR TITLE
Console improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,10 +32,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap",
- "env_logger",
  "lazy_static",
  "lazycell",
- "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
@@ -126,19 +115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7313c0d620d0cb4dbd9d019e461a4beb501071ff46ec0ab933efb4daa76d73e3"
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,12 +136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,9 +155,9 @@ checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -274,8 +244,6 @@ version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -326,6 +294,7 @@ name = "stardust"
 version = "0.1.0"
 dependencies = [
  "linked_list_allocator",
+ "log",
  "xen",
 ]
 
@@ -342,15 +311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -407,15 +367,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/stardust/Cargo.toml
+++ b/stardust/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 [dependencies]
 xen = { path = "../xen" }
 linked_list_allocator = "0.9"
+log = { version = "0.4", features = ["release_max_level_trace"] }

--- a/stardust/src/lib.rs
+++ b/stardust/src/lib.rs
@@ -9,14 +9,17 @@ extern crate alloc;
 use {
     alloc::{format, vec::Vec},
     core::{slice, str},
+    log::{debug, error},
     xen::{
         console::Writer,
         init_info, println,
         scheduler::{schedule_operation, Command, ShutdownReason},
+        sections::{edata, end, erodata, etext, text_start},
         xen_sys::start_info_t,
     },
 };
 
+pub mod logger;
 pub mod mm;
 pub mod trap;
 
@@ -28,6 +31,7 @@ pub fn launch(start_info: *mut start_info_t) {
     let start_info = unsafe { &*start_info };
 
     Writer::init(start_info);
+    logger::init();
 
     println!();
     println!("   _____ _____ _____ _____ _____ __ __ _____ _____ ");
@@ -70,18 +74,24 @@ fn print_start_info(start_info: &start_info_t) {
         slice::from_raw_parts(start_info.magic.as_ptr() as *const u8, 32)
     })
     .unwrap();
-    println!("    platform: {}", magic_str);
-    println!("    nr_pages: {}", start_info.nr_pages);
-    println!("    shared_info: {:#X}", start_info.shared_info);
-    println!("    pt_base: {:#X}", start_info.pt_base);
-    println!("    mfn_list: {:#X}", start_info.mfn_list);
-    println!("    mod_start: {:#X}", start_info.mod_start);
-    println!("    mod_len: {}", start_info.mod_len);
+    debug!("   platform: {}", magic_str);
+    debug!("   nr_pages: {}", start_info.nr_pages);
+    debug!("shared_info: {:#X}", start_info.shared_info);
+    debug!("    pt_base: {:#X}", start_info.pt_base);
+    debug!("   mfn_list: {:#X}", start_info.mfn_list);
+    debug!("  mod_start: {:#X}", start_info.mod_start);
+    debug!("    mod_len: {}", start_info.mod_len);
+    debug!("      _text: {:#X}", text_start());
+    debug!("     _etext: {:#X}", etext());
+    debug!("   _erodata: {:#X}", erodata());
+    debug!("     _edata: {:#X}", edata());
+    debug!("       _end: {:#X}", end());
+    debug!("");
 }
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
-    println!("{}", info);
+    error!("{}", info);
 
     Writer::flush();
 

--- a/stardust/src/logger.rs
+++ b/stardust/src/logger.rs
@@ -1,0 +1,41 @@
+//! Logger implementation
+
+use {
+    log::{Level, LevelFilter, Log, Metadata, Record},
+    xen::{console::Writer, println},
+};
+
+static LOGGER: Logger = Logger;
+
+/// Initialise logger using the xen::console backend
+pub fn init() {
+    log::set_logger(&LOGGER)
+        .map(|()| log::set_max_level(LevelFilter::Trace))
+        .expect("Failed to set logger");
+}
+
+struct Logger;
+
+impl Log for Logger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        println!("{} {}", format_level(record.level()), record.args());
+    }
+
+    fn flush(&self) {
+        Writer::flush();
+    }
+}
+
+fn format_level(level: Level) -> &'static str {
+    match level {
+        Level::Trace => "\x1b[0;35mTRACE\x1b[0m",
+        Level::Debug => "\x1b[0;34mDEBUG\x1b[0m",
+        Level::Info => "\x1b[0;32mINFO \x1b[0m",
+        Level::Warn => "\x1b[0;33mWARN \x1b[0m",
+        Level::Error => "\x1b[0;31mERROR\x1b[0m",
+    }
+}

--- a/stardust/src/main.rs
+++ b/stardust/src/main.rs
@@ -5,9 +5,6 @@ use xen::xen_sys::start_info_t;
 
 #[no_mangle]
 pub extern "C" fn start_kernel(start_info: *mut start_info_t) {
-    // SAFETY: safe to dereference raw pointer as it is valid when provided by Xen
-    let start_info = unsafe { &*start_info };
-
     // we have liftoff
     stardust::launch(start_info)
 }

--- a/stardust/src/mm/allocator.rs
+++ b/stardust/src/mm/allocator.rs
@@ -1,6 +1,9 @@
 //! Kernel memory allocator
 
-use {crate::mm::util::VirtualAddress, linked_list_allocator::LockedHeap, xen::println};
+use {
+    linked_list_allocator::LockedHeap,
+    xen::{mm::VirtualAddress, println},
+};
 
 #[global_allocator]
 static ALLOCATOR: LockedHeap = LockedHeap::empty();

--- a/stardust/src/mm/allocator.rs
+++ b/stardust/src/mm/allocator.rs
@@ -1,16 +1,13 @@
 //! Kernel memory allocator
 
-use {
-    linked_list_allocator::LockedHeap,
-    xen::{mm::VirtualAddress, println},
-};
+use {linked_list_allocator::LockedHeap, log::info, xen::mm::VirtualAddress};
 
 #[global_allocator]
 static ALLOCATOR: LockedHeap = LockedHeap::empty();
 
 /// Initialize allocator
 pub unsafe fn init(heap_start: VirtualAddress, heap_size: usize) {
-    println!(
+    info!(
         "Initialising allocator with heap start {:#x} and length {}",
         heap_start.0, heap_size
     );

--- a/stardust/src/mm/mod.rs
+++ b/stardust/src/mm/mod.rs
@@ -2,6 +2,7 @@
 
 use {
     core::{cmp::min, convert::TryInto, mem::size_of, ptr},
+    log::{debug, info, trace},
     xen::{
         memory::{get_current_pages, get_max_pages, hypervisor_mmu_update},
         mm::{
@@ -12,8 +13,7 @@ use {
             L1_PAGETABLE_ENTRIES, L1_PROT, MAX_MEM_SIZE, PAGETABLE_LEVELS, PAGE_MASK, PAGE_PRESENT,
             PAGE_RW, PAGE_SHIFT, PAGE_SIZE, PT_PROT,
         },
-        println,
-        sections::{edata, end, erodata, etext, text_start},
+        sections::end,
         xen_sys::{mmu_update_t, start_info_t, __HYPERVISOR_VIRT_START},
     },
 };
@@ -22,13 +22,7 @@ pub mod allocator;
 
 /// Initialise kernel memory management
 pub fn init(start_info: &start_info_t) {
-    println!();
-    println!("Initalising kernel memory management...");
-    println!("                 _text: {:#X}", text_start());
-    println!("                _etext: {:#X}", etext());
-    println!("              _erodata: {:#X}", erodata());
-    println!("                _edata: {:#X}", edata());
-    println!("                  _end: {:#X}", end());
+    info!("Initalising memory management");
 
     if start_info.mfn_list < end() as u64 {
         panic!("MFN_LIST must be beyond end of program, this can cause corruption!")
@@ -55,11 +49,11 @@ pub fn init(start_info: &start_info_t) {
     // cannot have more pages than the maximum amount of memory on the current platform
     let max_pfn = PageFrameNumber(min(nr_pages, (MAX_MEM_SIZE / PAGE_SIZE) - 1));
 
-    println!("             start_pfn: {:?}", start_pfn.0);
-    println!("               max_pfn: {:?}", max_pfn.0);
+    debug!("             start_pfn: {:?}", start_pfn.0);
+    debug!("               max_pfn: {:?}", max_pfn.0);
 
-    println!("current reserved pages: {}", get_current_pages());
-    println!("    max reserved pages: {}", get_max_pages());
+    debug!("current reserved pages: {}", get_current_pages());
+    debug!("    max reserved pages: {}", get_max_pages());
 
     let (start_address, size) = unsafe { build_pagetable(pt_base, start_pfn, max_pfn) };
 
@@ -85,7 +79,7 @@ unsafe fn build_pagetable(
     let start_address = VirtualAddress::from(start_pfn);
     let end_address = VirtualAddress::from(max_pfn);
 
-    println!(
+    debug!(
         "Mapping memory range {:#x} - {:#x}",
         start_address.0, end_address.0
     );
@@ -202,9 +196,12 @@ unsafe fn new_pt_frame(
 
     let mut mmu_updates = [mmu_update_t { ptr: 0, val: 0 }; 1];
 
-    println!(
+    trace!(
         "Allocating new L{} page table frame for pfn={}, prev_l_mfn={}, offset={}",
-        level, pt_pfn.0, prev_l_mfn.0, offset
+        level,
+        pt_pfn.0,
+        prev_l_mfn.0,
+        offset
     );
 
     // clear the page otherwise might fail to map it as a page table page

--- a/stardust/src/mm/mod.rs
+++ b/stardust/src/mm/mod.rs
@@ -2,12 +2,12 @@
 
 use {
     core::{cmp::min, convert::TryInto, mem::size_of, ptr},
-    util::{
-        init_mfn_list, l1_table_offset, l2_table_offset, l3_table_offset, l4_table_offset, pfn_up,
-        MachineFrameNumber, PageEntry, PageFrameNumber, PhysicalAddress, VirtualAddress,
-    },
     xen::{
         memory::{get_current_pages, get_max_pages, hypervisor_mmu_update},
+        mm::{
+            l1_table_offset, l2_table_offset, l3_table_offset, l4_table_offset, pfn_up,
+            MachineFrameNumber, PageEntry, PageFrameNumber, PhysicalAddress, VirtualAddress,
+        },
         platform::consts::{
             L1_PAGETABLE_ENTRIES, L1_PROT, MAX_MEM_SIZE, PAGETABLE_LEVELS, PAGE_MASK, PAGE_PRESENT,
             PAGE_RW, PAGE_SHIFT, PAGE_SIZE, PT_PROT,
@@ -19,7 +19,6 @@ use {
 };
 
 pub mod allocator;
-pub mod util;
 
 /// Initialise kernel memory management
 pub fn init(start_info: &start_info_t) {
@@ -34,14 +33,6 @@ pub fn init(start_info: &start_info_t) {
     if start_info.mfn_list < end() as u64 {
         panic!("MFN_LIST must be beyond end of program, this can cause corruption!")
     }
-
-    // initialize the mapping between page frame numbers and machine frame numbers
-    init_mfn_list(
-        start_info
-            .mfn_list
-            .try_into()
-            .expect("mfn_list could not be converted to a usize"),
-    );
 
     // construct pointer to base of page table
     let pt_base = start_info.pt_base as *mut PageEntry;

--- a/xen-sys/Cargo.toml
+++ b/xen-sys/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 cty = "0.2"
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = { version = "0.59", default-features = false, features = ["clap", "runtime", "which-rustfmt"] }

--- a/xen/link.x
+++ b/xen/link.x
@@ -56,7 +56,7 @@ SECTIONS
 
         . = ALIGN(4096) ;
         __STACK_START = . ;
-        . += 4096 ; /* Defines stack size, must be power of 2 */
+        . += 8192 ; /* Defines stack size, must be power of 2 */
         __STACK_END = . ;
   }
   _end = . ;

--- a/xen/src/events.rs
+++ b/xen/src/events.rs
@@ -1,0 +1,72 @@
+//! Interface to Xen event channels
+
+use core::convert::TryInto;
+
+use crate::{
+    platform::util::{synch_clear_bit, synch_set_bit},
+    println, SHARED_INFO,
+};
+
+/// Number of event channel ports
+pub const NUM_EVENT_PORTS: usize = 1024;
+
+/// Actions for each event channel
+pub static mut EVENT_ACTIONS: [EventAction; NUM_EVENT_PORTS] = [EventAction {
+    handler: DEFAULT_HANDLER,
+    data: 0,
+    count: 0,
+}; NUM_EVENT_PORTS];
+
+/// Default event handler
+pub static DEFAULT_HANDLER: fn(usize, *mut u8) =
+    |port, _| println!("received event on port {}", port);
+
+/// Action associated with event
+#[derive(Clone, Copy, Debug)]
+pub struct EventAction {
+    handler: fn(usize, *mut u8),
+    data: usize,
+    count: u32,
+}
+
+/// Initialise events, set default handler and mask all event ports
+pub fn init() {
+    for i in 0..unsafe { EVENT_ACTIONS.len() } {
+        mask_event_channel(i);
+    }
+}
+
+/// Bind an event handler to an event channel
+pub fn bind_event_channel(port: usize, handler: fn(usize, *mut u8), data: usize) {
+    if unsafe { EVENT_ACTIONS[port].handler != DEFAULT_HANDLER } {
+        println!(
+            "Warning: handler for port {} already registered, replacing",
+            port,
+        );
+    }
+
+    unsafe {
+        EVENT_ACTIONS[port].data = data;
+        EVENT_ACTIONS[port].count = 0;
+        EVENT_ACTIONS[port].handler = handler;
+    }
+    unmask_event_channel(port);
+}
+
+fn mask_event_channel(port: usize) {
+    unsafe {
+        synch_set_bit(
+            port.try_into().expect("Failed to convert usize to u64"),
+            &mut (*SHARED_INFO).evtchn_mask[0],
+        )
+    }
+}
+
+fn unmask_event_channel(port: usize) {
+    unsafe {
+        synch_clear_bit(
+            port.try_into().expect("failed to convert usize to u64"),
+            &mut (*SHARED_INFO).evtchn_mask[0],
+        )
+    };
+}

--- a/xen/src/lib.rs
+++ b/xen/src/lib.rs
@@ -5,13 +5,19 @@
 #![feature(asm)]
 #![deny(missing_docs)]
 
-use xen_sys::{domid_t, XENFEAT_NR_SUBMAPS};
+use core::convert::TryInto;
+
+use xen_sys::{
+    __HYPERVISOR_update_va_mapping, domid_t, shared_info, start_info, XENFEAT_NR_SUBMAPS,
+};
 
 pub use xen_sys;
 
 pub mod console;
+pub mod events;
 pub mod hypercall;
 pub mod memory;
+pub mod mm;
 pub mod platform;
 pub mod scheduler;
 pub mod sections;
@@ -24,3 +30,34 @@ pub const DOMID_SELF: domid_t = 0x7FF0;
 #[no_mangle]
 pub static mut xen_features: [u8; XENFEAT_NR_SUBMAPS as usize * 32] =
     [0; XENFEAT_NR_SUBMAPS as usize * 32];
+
+/// Xen static startup information
+pub static mut START_INFO: *mut start_info = core::ptr::null_mut();
+
+/// Xen dynamic global state information
+pub static mut SHARED_INFO: *mut shared_info = core::ptr::null_mut();
+
+/// Map shared info page, initialise start and shared info pointers
+pub fn init_info(start_info: *mut start_info) {
+    unsafe { START_INFO = start_info };
+
+    mm::init_mfn_list(
+        unsafe { *START_INFO }
+            .mfn_list
+            .try_into()
+            .expect("Failed to convert u64 to usize"),
+    );
+
+    let rc = unsafe {
+        hypercall!(
+            __HYPERVISOR_update_va_mapping,
+            SHARED_INFO as u64,
+            (*START_INFO).shared_info | 7,
+            2u64
+        )
+    };
+
+    if rc != 0 {
+        panic!("Failed to map shared info page with error: {}", rc);
+    }
+}

--- a/xen/src/platform/mod.rs
+++ b/xen/src/platform/mod.rs
@@ -4,4 +4,4 @@
 mod x86_64;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use x86_64::{consts, hypercall};
+pub use x86_64::{consts, hypercall, util};

--- a/xen/src/platform/x86_64/mod.rs
+++ b/xen/src/platform/x86_64/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod consts;
 pub mod hypercall;
+pub mod util;

--- a/xen/src/platform/x86_64/util.rs
+++ b/xen/src/platform/x86_64/util.rs
@@ -1,0 +1,11 @@
+//! Utility functions
+
+/// Synchronised bit set
+pub unsafe fn synch_set_bit(nr: u64, addr: *mut u64) {
+    asm!("lock", "bts [{}], {}", in(reg) addr, in(reg) nr);
+}
+
+/// Synchronised bit clear
+pub unsafe fn synch_clear_bit(nr: u64, addr: *mut u64) {
+    asm!("lock", "btr [{}], {}", in(reg) addr, in(reg) nr);
+}


### PR DESCRIPTION
Improves console write performance between 20x and 60x depending on the length of each line being printed.

Original implementation wrote text byte by byte and yielded until buffer was flushed before continuing whereas new implementation fills buffer and issues `send` events.

## Before

<img width="773" alt="Screenshot 2021-11-25 at 18 57 37" src="https://user-images.githubusercontent.com/8290136/143576199-09a19ef5-0e50-4146-a34a-48fc6af614bd.png">

## After
<img width="773" alt="Screenshot 2021-11-25 at 18 58 21" src="https://user-images.githubusercontent.com/8290136/143576204-b335288e-1209-4bdc-aa45-ee1040729137.png">
